### PR TITLE
Enable Windows targeting and upgrade Noggog packages to 4.2.0-alpha.9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <Authors>Noggog</Authors>
         <PackageOutputPath>..\nupkg</PackageOutputPath>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,10 +31,10 @@
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Noggog.Autofac" Version="4.2.0-alpha.8" />
-    <PackageVersion Include="Noggog.CSharpExt" Version="4.2.0-alpha.8" />
-    <PackageVersion Include="Noggog.Testing" Version="4.2.0-alpha.8" />
-    <PackageVersion Include="Noggog.WPF" Version="4.2.0-alpha.8" />
+    <PackageVersion Include="Noggog.Autofac" Version="4.2.0-alpha.9" />
+    <PackageVersion Include="Noggog.CSharpExt" Version="4.2.0-alpha.9" />
+    <PackageVersion Include="Noggog.Testing" Version="4.2.0-alpha.9" />
+    <PackageVersion Include="Noggog.WPF" Version="4.2.0-alpha.9" />
     <PackageVersion Include="ReactiveUI" Version="21.0.1" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" PrivateAssets="all" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,10 +31,10 @@
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Noggog.Autofac" Version="4.0.0" />
-    <PackageVersion Include="Noggog.CSharpExt" Version="4.0.0" />
-    <PackageVersion Include="Noggog.Testing" Version="4.0.0" />
-    <PackageVersion Include="Noggog.WPF" Version="4.0.0" />
+    <PackageVersion Include="Noggog.Autofac" Version="4.2.0-alpha.8" />
+    <PackageVersion Include="Noggog.CSharpExt" Version="4.2.0-alpha.8" />
+    <PackageVersion Include="Noggog.Testing" Version="4.2.0-alpha.8" />
+    <PackageVersion Include="Noggog.WPF" Version="4.2.0-alpha.8" />
     <PackageVersion Include="ReactiveUI" Version="21.0.1" />
     <PackageVersion Include="ReactiveUI.Fody" Version="19.5.41" />
     <PackageVersion Include="ReactiveMarbles.ObservableEvents.SourceGenerator" Version="1.3.1" PrivateAssets="all" />

--- a/Mutagen.Bethesda.Tests.GUI/ViewModels/Configuration/DataFolderVM.cs
+++ b/Mutagen.Bethesda.Tests.GUI/ViewModels/Configuration/DataFolderVM.cs
@@ -6,7 +6,7 @@ public class DataFolderVM : ViewModel
 {
     public GameRelease GameRelease { get; }
 
-    public PathPickerVM DataFolder { get; } = new PathPickerVM()
+    public PathPickerVM DataFolder { get; } = new PathPickerVM(new SchedulerProvider())
     {
         PathType = PathPickerVM.PathTypeOptions.Folder,
         ExistCheckOption = PathPickerVM.CheckOptions.IfPathNotEmpty

--- a/Mutagen.Bethesda.Tests.GUI/ViewModels/Configuration/PassthroughVM.cs
+++ b/Mutagen.Bethesda.Tests.GUI/ViewModels/Configuration/PassthroughVM.cs
@@ -7,7 +7,7 @@ namespace Mutagen.Bethesda.Tests.GUI;
 
 public class PassthroughVM : ViewModel
 {
-    public PathPickerVM Path { get; } = new()
+    public PathPickerVM Path { get; } = new(new SchedulerProvider())
     {
         ExistCheckOption = PathPickerVM.CheckOptions.On,
         PathType = PathPickerVM.PathTypeOptions.File,

--- a/Mutagen.Bethesda.Tests.GUI/ViewModels/MainVM.cs
+++ b/Mutagen.Bethesda.Tests.GUI/ViewModels/MainVM.cs
@@ -18,7 +18,7 @@ namespace Mutagen.Bethesda.Tests.GUI;
 public class MainVM : ViewModel
 {
     [JsonProperty]
-    public PathPickerVM SelectedConfigPath { get; } = new()
+    public PathPickerVM SelectedConfigPath { get; } = new(new SchedulerProvider())
     {
         PathType = PathPickerVM.PathTypeOptions.File,
         ExistCheckOption = PathPickerVM.CheckOptions.On,

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="local" value="../local-nupkgs" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="local" value="../local-nupkgs" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary

- Add `<EnableWindowsTargeting>true</EnableWindowsTargeting>` to `Directory.Build.props` to allow building Windows-targeted projects (WPF) on non-Windows platforms
- Upgrade Noggog.Autofac, Noggog.CSharpExt, Noggog.Testing, and Noggog.WPF from **4.0.0** to **4.2.0-alpha.9**
- Fix breaking change in Noggog.WPF: `PathPickerVM` constructor now requires an `ISchedulerProvider` parameter. Updated all 3 call sites in `Mutagen.Bethesda.Tests.GUI` to pass `new SchedulerProvider()`

## Files Changed

| File | Change |
|------|--------|
| `Directory.Build.props` | Add `EnableWindowsTargeting` property |
| `Directory.Packages.props` | Bump 4 Noggog package versions |
| `Mutagen.Bethesda.Tests.GUI/ViewModels/Configuration/DataFolderVM.cs` | Pass `SchedulerProvider` to `PathPickerVM` |
| `Mutagen.Bethesda.Tests.GUI/ViewModels/Configuration/PassthroughVM.cs` | Pass `SchedulerProvider` to `PathPickerVM` |
| `Mutagen.Bethesda.Tests.GUI/ViewModels/MainVM.cs` | Pass `SchedulerProvider` to `PathPickerVM` |